### PR TITLE
feat: add pricebuddy application

### DIFF
--- a/kubernetes/apps/pricebuddy/kustomization.yaml
+++ b/kubernetes/apps/pricebuddy/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: pricebuddy
+components:
+  - ../../components/common
+resources:
+  - ./pricebuddy/ks.yaml

--- a/kubernetes/apps/pricebuddy/pricebuddy/app/database-deployment.yaml
+++ b/kubernetes/apps/pricebuddy/pricebuddy/app/database-deployment.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pricebuddy-database
+  labels:
+    app.kubernetes.io/name: pricebuddy
+    app.kubernetes.io/instance: pricebuddy-database
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: pricebuddy
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pricebuddy
+      app.kubernetes.io/component: database
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pricebuddy
+        app.kubernetes.io/instance: pricebuddy-database
+        app.kubernetes.io/component: database
+        app.kubernetes.io/part-of: pricebuddy
+    spec:
+      containers:
+        - name: mysql
+          image: mysql:8.2
+          ports:
+            - containerPort: 3306
+              name: mysql
+          env:
+            - name: MYSQL_DATABASE
+              value: pricebuddy
+            - name: MYSQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: pricebuddy-secrets
+                  key: db-username
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: pricebuddy-secrets
+                  key: db-password
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: pricebuddy-secrets
+                  key: db-root-password
+          volumeMounts:
+            - name: mysql-data
+              mountPath: /var/lib/mysql
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
+          livenessProbe:
+            exec:
+              command:
+                - mysqladmin
+                - ping
+                - -h
+                - localhost
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - mysqladmin
+                - ping
+                - -h
+                - localhost
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+      volumes:
+        - name: mysql-data
+          persistentVolumeClaim:
+            claimName: pricebuddy-mysql-data

--- a/kubernetes/apps/pricebuddy/pricebuddy/app/deployment.yaml
+++ b/kubernetes/apps/pricebuddy/pricebuddy/app/deployment.yaml
@@ -1,0 +1,112 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pricebuddy
+  labels:
+    app.kubernetes.io/name: pricebuddy
+    app.kubernetes.io/instance: pricebuddy
+    app.kubernetes.io/component: app
+    app.kubernetes.io/part-of: pricebuddy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pricebuddy
+      app.kubernetes.io/component: app
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pricebuddy
+        app.kubernetes.io/instance: pricebuddy
+        app.kubernetes.io/component: app
+        app.kubernetes.io/part-of: pricebuddy
+    spec:
+      initContainers:
+        # Wait for database to be ready before starting app
+        - name: wait-for-db
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              until nc -z pricebuddy-database 3306; do
+                echo "Waiting for database..."
+                sleep 2
+              done
+              echo "Database is ready"
+      containers:
+        - name: pricebuddy
+          # TODO: Pin to a specific version tag when available
+          image: jez500/pricebuddy:latest
+          ports:
+            - containerPort: 80
+              name: http
+          env:
+            - name: APP_URL
+              value: https://pricebuddy.endsys.cloud
+            - name: DB_CONNECTION
+              value: mysql
+            - name: DB_HOST
+              value: pricebuddy-database
+            - name: DB_PORT
+              value: "3306"
+            - name: DB_DATABASE
+              value: pricebuddy
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: pricebuddy-secrets
+                  key: db-username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: pricebuddy-secrets
+                  key: db-password
+            - name: SCRAPPER_URL
+              value: http://pricebuddy-scraper:3000
+            - name: ENABLE_AFFILIATE_FEATURE
+              value: "false"
+            # Admin seeding credentials
+            - name: SEED_ADMIN_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: pricebuddy-secrets
+                  key: admin-name
+            - name: SEED_ADMIN_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: pricebuddy-secrets
+                  key: admin-email
+            - name: SEED_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: pricebuddy-secrets
+                  key: admin-password
+          volumeMounts:
+            - name: storage
+              mountPath: /var/www/html/storage/app
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+      volumes:
+        - name: storage
+          persistentVolumeClaim:
+            claimName: pricebuddy-storage

--- a/kubernetes/apps/pricebuddy/pricebuddy/app/httproute.yaml
+++ b/kubernetes/apps/pricebuddy/pricebuddy/app/httproute.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: pricebuddy
+  labels:
+    app.kubernetes.io/name: pricebuddy
+spec:
+  parentRefs:
+    - name: internal
+      namespace: kube-system
+      sectionName: https
+  hostnames: ["pricebuddy.endsys.cloud"]
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: pricebuddy
+          port: 80

--- a/kubernetes/apps/pricebuddy/pricebuddy/app/kustomization.yaml
+++ b/kubernetes/apps/pricebuddy/pricebuddy/app/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./deployment.yaml
+  - ./database-deployment.yaml
+  - ./scraper-deployment.yaml
+  - ./service.yaml
+  - ./pvc.yaml
+  - ./httproute.yaml
+  - ./secret.sops.yaml

--- a/kubernetes/apps/pricebuddy/pricebuddy/app/pvc.yaml
+++ b/kubernetes/apps/pricebuddy/pricebuddy/app/pvc.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pricebuddy-storage
+  labels:
+    app.kubernetes.io/name: pricebuddy
+    app.kubernetes.io/component: app
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pricebuddy-mysql-data
+  labels:
+    app.kubernetes.io/name: pricebuddy
+    app.kubernetes.io/component: database
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/kubernetes/apps/pricebuddy/pricebuddy/app/scraper-deployment.yaml
+++ b/kubernetes/apps/pricebuddy/pricebuddy/app/scraper-deployment.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pricebuddy-scraper
+  labels:
+    app.kubernetes.io/name: pricebuddy
+    app.kubernetes.io/instance: pricebuddy-scraper
+    app.kubernetes.io/component: scraper
+    app.kubernetes.io/part-of: pricebuddy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pricebuddy
+      app.kubernetes.io/component: scraper
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pricebuddy
+        app.kubernetes.io/instance: pricebuddy-scraper
+        app.kubernetes.io/component: scraper
+        app.kubernetes.io/part-of: pricebuddy
+    spec:
+      containers:
+        - name: scraper
+          # TODO: Pin to a specific version tag when available
+          image: jez500/seleniumbase-scrapper:latest
+          ports:
+            - containerPort: 3000
+              name: http
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5

--- a/kubernetes/apps/pricebuddy/pricebuddy/app/secret.sops.yaml
+++ b/kubernetes/apps/pricebuddy/pricebuddy/app/secret.sops.yaml
@@ -1,0 +1,17 @@
+# IMPORTANT: This file must be encrypted with SOPS before committing
+# Run: sops -e -i secret.sops.yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pricebuddy-secrets
+type: Opaque
+stringData:
+  # Database credentials
+  db-username: pricebuddy
+  db-password: CHANGE_ME_DB_PASSWORD
+  db-root-password: CHANGE_ME_ROOT_PASSWORD
+  # Admin user credentials (for initial seeding)
+  admin-name: Admin
+  admin-email: admin@endsys.cloud
+  admin-password: CHANGE_ME_ADMIN_PASSWORD

--- a/kubernetes/apps/pricebuddy/pricebuddy/app/service.yaml
+++ b/kubernetes/apps/pricebuddy/pricebuddy/app/service.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pricebuddy
+  labels:
+    app.kubernetes.io/name: pricebuddy
+    app.kubernetes.io/component: app
+spec:
+  selector:
+    app.kubernetes.io/name: pricebuddy
+    app.kubernetes.io/component: app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+      name: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pricebuddy-database
+  labels:
+    app.kubernetes.io/name: pricebuddy
+    app.kubernetes.io/component: database
+spec:
+  selector:
+    app.kubernetes.io/name: pricebuddy
+    app.kubernetes.io/component: database
+  ports:
+    - protocol: TCP
+      port: 3306
+      targetPort: 3306
+      name: mysql
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pricebuddy-scraper
+  labels:
+    app.kubernetes.io/name: pricebuddy
+    app.kubernetes.io/component: scraper
+spec:
+  selector:
+    app.kubernetes.io/name: pricebuddy
+    app.kubernetes.io/component: scraper
+  ports:
+    - protocol: TCP
+      port: 3000
+      targetPort: 3000
+      name: http

--- a/kubernetes/apps/pricebuddy/pricebuddy/ks.yaml
+++ b/kubernetes/apps/pricebuddy/pricebuddy/ks.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app pricebuddy
+  namespace: &namespace pricebuddy
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  interval: 1h
+  path: ./kubernetes/apps/pricebuddy/pricebuddy/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
Adds PriceBuddy price tracking application with:
- Main app (jez500/pricebuddy)
- MySQL 8.2 database
- Selenium-based scraper service
- Internal HTTPRoute at pricebuddy.endsys.cloud
- PVCs for storage (5Gi) and database (10Gi)

Note: secret.sops.yaml needs to be encrypted before deployment.