### PR TITLE
ci: prepare Garage chart for flux-local tests

### DIFF
--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -35,6 +35,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Prepare Garage Helm chart
+        run: |
+          GARAGE_REF="$(awk '/tag:/ { print $2; exit }' kubernetes/flux/meta/repos/garage.yaml)"
+          git clone --depth 1 --branch "${GARAGE_REF}" https://git.deuxfleurs.fr/Deuxfleurs/garage /tmp/garage
+          mkdir -p script/helm
+          cp -R /tmp/garage/script/helm/garage script/helm/garage
+
       - name: Run flux-local test
         uses: docker://ghcr.io/allenporter/flux-local:v8.0.1
         with:


### PR DESCRIPTION
## Summary
- Clones Garage's upstream repository at the tag declared in `kubernetes/flux/meta/repos/garage.yaml` before running `flux-local test`.
- Provides the local `script/helm/garage` path that flux-local expects for GitRepository-backed HelmReleases.
- Keeps the runtime Flux source unchanged while unblocking Renovate PR validation.

## Validation
- `git diff --check`
- Parsed `.github/workflows/flux-local.yaml` as YAML with Ruby
- Rendered the upstream Garage chart locally with the current Helm values