### PR TITLE
feat(container): update image mysql ( 8.2 → 8.4 LTS )

### DIFF
--- a/kubernetes/apps/pricebuddy/pricebuddy/app/database-deployment.yaml
+++ b/kubernetes/apps/pricebuddy/pricebuddy/app/database-deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: mysql
-          image: mysql:8.2
+          image: mysql:8.4
           ports:
             - containerPort: 3306
               name: mysql


### PR DESCRIPTION
Supersedes #226.

Renovate proposed MySQL `8.2 → 9.7`, but [MySQL upgrade rules](https://dev.mysql.com/doc/refman/9.7/en/upgrade-paths.html) forbid skipping the LTS release: you **cannot** jump from an Innovation release (8.2) directly to 9.x — the path is **8.2 → 8.4 LTS → 9.x**. Starting mysqld 9.7 on the existing 8.2 datadir would fail the data-dictionary upgrade, and 9.0 removed `mysql_native_password`.

This PR takes the safe first hop to **8.4 LTS** (supported in-place datadir upgrade for pricebuddy). A future PR can take 8.4 → 9.x if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)