### PR TITLE
feat(romm): deploy ROMM

### DIFF
--- a/.hermes/ledger/2026-07-14-romm-deployment.md
+++ b/.hermes/ledger/2026-07-14-romm-deployment.md
@@ -34,12 +34,11 @@
 - [x] Feature commits complete
 - [ ] Live mutation approvals received
 - [x] NFS applied and verified
-- [ ] Secret created and verified
+- [x] Secret created and verified
 - [ ] GitOps deployed and live health verified
 
 ## Approval gates still closed
 
-- Bitwarden secret creation
 - Kubernetes server-side dry-run (blocked by the homelab gate)
 - Pull request creation / merge
 - Live Flux reconciliation
@@ -72,7 +71,7 @@ Ansible checks in `/home/sean/workspace/endsys-ansible-romm`:
 - Approved NFS apply reported `ok=32 changed=3 unreachable=0 failed=0`; the third change is the export reload handler. Backup: `/etc/exports.pre-romm-20260715T073321-0400`.
 - Post-apply verification: live export is RW with `root_squash`; `/vault/games` is `1000:1000/0775`; a UID/GID 1000 create/delete NFS probe passed; no probe mounts/files remained; ZFS is healthy; idempotency check passed with `changed=0 failed=0`.
 
-NFS live state changed only as recorded above. No Kubernetes, Bitwarden, or Flux live state has been changed. Ahead-only feature branches were pushed; no pull request or merge was created.
+NFS live state changed only as recorded above. No Kubernetes or Flux live state has been changed. Ahead-only feature branches were pushed; no pull request or merge was created.
 
 ## Bitwarden secret rollout
 
@@ -81,4 +80,5 @@ NFS live state changed only as recorded above. No Kubernetes, Bitwarden, or Flux
 - With explicit approval, the cluster-held token was loaded only into process memory. Project lookup passed and the pre-create count for `romm-auth-secret-key` was `0`.
 - `bws secret create ... --output none` failed with `404 Resource not found`; a post-error count confirmed the key remains absent (`0`). Sensitive variables were removed by the shell exit trap, and no value was printed or written to disk.
 - Classification: the machine account has read-only project access. The error exactly matches Bitwarden SDK issue [#1287](https://github.com/bitwarden/sdk-sm/issues/1287), which documents this misleading `404` when create permission is missing.
-- Blocker: temporarily grant that machine account **Can read, write** on the existing project, or create the key manually in the Bitwarden web app. No retry is warranted until permission changes.
+- Sean created `romm-auth-secret-key` manually in the `endsys-gitops` project. The value was never sent through chat or read back by Mimir.
+- Value-free BWS verification passed: the matching-key count is exactly `1`.

--- a/.hermes/ledger/2026-07-14-romm-deployment.md
+++ b/.hermes/ledger/2026-07-14-romm-deployment.md
@@ -1,0 +1,73 @@
+# ROMM Deployment Ledger
+
+**Date:** 2026-07-14
+**Plan:** `.hermes/plans/2026-07-14_190017-romm-deployment.md`
+**GitOps branch:** `feat/romm`
+**Ansible branch:** `feat/romm-nfs`
+
+## Confirmed inputs
+
+- User selected option 1: reuse `/vault/games` read/write.
+- Lyris is `10.127.0.7`.
+- Live `/vault/games` is approximately 355 GiB and currently exists as `root:root`, mode `0777`.
+- Existing structure includes `/vault/games/roms/{n64,nes,Nintendo Gameboy,Nintendo Gameboy Advance,the-eye.eu}` and `/vault/games/roms_other`.
+- Existing NFS exports do not include `/vault/games`.
+- Cluster nodes are amd64; Longhorn has ample current free capacity for the planned application-state claims.
+- ROMM 4.9.2 supports PostgreSQL, external Redis-compatible caches, `/romm/library`, `/romm/resources`, `/romm/assets`, and `/romm/config/config.yml`.
+- ROMM's dedicated unauthenticated health endpoint is `/api/heartbeat`.
+
+## Decisions
+
+- Existing game bytes will not be copied, moved, renamed, scanned, or deleted by infrastructure automation.
+- `/vault/games` will be exported to `10.127.0.0/24` with `root_squash`.
+- ROMM is internal-only for initial deployment.
+- Local setup wizard precedes optional Pocket ID OIDC.
+- Velero will exclude the NFS library volume.
+
+## Status
+
+- [x] Discovery and storage choice
+- [x] Implementation plan written
+- [x] Ansible desired state implemented
+- [x] GitOps manifests implemented
+- [x] Static/render validation complete
+- [ ] Feature commits complete
+- [ ] Live mutation approvals received
+- [ ] NFS applied and verified
+- [ ] Secret created and verified
+- [ ] GitOps deployed and live health verified
+
+## Approval gates still closed
+
+- Bitwarden secret creation
+- Lyris NFS apply
+- Kubernetes server-side dry-run (blocked by the homelab gate)
+- Pull request creation / merge
+- Live Flux reconciliation
+
+## Verification evidence
+
+GitOps checks run independently after both Claude Code workers exhausted their turn budgets:
+
+- `kubectl kustomize kubernetes/apps/romm`: pass.
+- `kubectl kustomize kubernetes/apps/velero/velero/app`: pass.
+- `kubectl kustomize kubernetes/apps`: pass.
+- `yamllint` across all changed manifests with only line-length disabled for schema URLs: pass.
+- Helm `4.2.3` and kubeconform `0.8.0` scratch downloads: published SHA-256 checks passed.
+- app-template `5.0.1` render using the exact HelmRelease values: pass; generated ServiceAccount, two retained PVCs, Service, and Deployment were inspected.
+- Docker manifest inspection confirmed `rommapp/romm:4.9.2` includes `linux/amd64` and resolves to the tagged release commit `3e629ba6998ac8badf6cadd71ae8b46c9c85b17f`.
+- Published-image smoke as UID/GID 1000 with all capabilities dropped and no privilege escalation: ROMM 4.9.2 initialized, accepted the read-only Git-managed config, honored external Redis, and reached PostgreSQL migrations. Exit 1 was expected because the disposable test deliberately pointed PostgreSQL at an absent loopback endpoint. A prior `/app`-path test was discarded because that source-build layout is not the published release-image layout.
+- Live read-only Lyris check: `sean` is UID/GID 1000 and all known game-library directories are mode `0777`. The Ansible share item sets the export root to `1000:1000/0775`; with `fsGroupChangePolicy: OnRootMismatch`, Kubernetes can avoid a recursive ownership walk through the 355 GiB library.
+- Strict kubeconform with core and CRD-catalog schemas after `SECRET_DOMAIN=example.com` substitution: 8/8 ROMM app resources valid, 1/1 Flux Kustomization valid, and 1/1 Velero Schedule valid.
+- `git diff --check`: pass.
+- Kubernetes server-side dry-run: not run; the homelab gate blocked the exact `kubectl apply --dry-run=server` commands and explicitly prohibited retrying or working around the block.
+
+Ansible checks in `/home/sean/workspace/endsys-ansible-romm`:
+
+- `ansible-playbook -i inventory/hosts.yml playbooks/nas.yml --syntax-check --check`: pass.
+- `yamllint inventory/host_vars/lyris/nas.yml`: pass.
+- `ansible-lint playbooks/nas.yml roles/nas`: pass with zero failures and warnings.
+- Local exports template render: pass, including `/vault/games    10.127.0.0/24(rw,sync,no_subtree_check,root_squash)`.
+- Live check mode: blocked by authentication/privilege prerequisites (`momo` key rejected; `docker_ops` has no passwordless sudo).
+
+No NFS, Kubernetes, Bitwarden, GitHub, or Flux live state has been changed.

--- a/.hermes/ledger/2026-07-14-romm-deployment.md
+++ b/.hermes/ledger/2026-07-14-romm-deployment.md
@@ -68,6 +68,7 @@ Ansible checks in `/home/sean/workspace/endsys-ansible-romm`:
 - `yamllint inventory/host_vars/lyris/nas.yml`: pass.
 - `ansible-lint playbooks/nas.yml roles/nas`: pass with zero failures and warnings.
 - Local exports template render: pass, including `/vault/games    10.127.0.0/24(rw,sync,no_subtree_check,root_squash)`.
-- Live check mode: blocked by authentication/privilege prerequisites (`momo` key rejected; `docker_ops` has no passwordless sudo).
+- Direct SSH and Ansible become preflight through `momo` with `/home/sean/.ssh/momo`: pass; `ping: pong` and passwordless become returned UID `0`.
+- Live NFS check mode with the explicit Momo key: pass; `changed=2`, `unreachable=0`, `failed=0`. The only predicted changes are `/vault/games` root metadata (`0:0/0777` to `1000:1000/0775`) and the intended export line.
 
-No NFS, Kubernetes, Bitwarden, GitHub, or Flux live state has been changed.
+No NFS, Kubernetes, Bitwarden, or Flux live state has been changed. Ahead-only feature branches were pushed; no pull request or merge was created.

--- a/.hermes/ledger/2026-07-14-romm-deployment.md
+++ b/.hermes/ledger/2026-07-14-romm-deployment.md
@@ -73,3 +73,12 @@ Ansible checks in `/home/sean/workspace/endsys-ansible-romm`:
 - Post-apply verification: live export is RW with `root_squash`; `/vault/games` is `1000:1000/0775`; a UID/GID 1000 create/delete NFS probe passed; no probe mounts/files remained; ZFS is healthy; idempotency check passed with `changed=0 failed=0`.
 
 NFS live state changed only as recorded above. No Kubernetes, Bitwarden, or Flux live state has been changed. Ahead-only feature branches were pushed; no pull request or merge was created.
+
+## Bitwarden secret rollout
+
+- Scratch CLI: official BWS `2.1.0`; the x86-64 GNU/Linux archive passed its published SHA-256 checksum.
+- Existing `bitwarden-secretsmanager` ClusterSecretStore is Ready, has a project ID, and references `external-secrets/bitwarden-access-token` key `token`.
+- With explicit approval, the cluster-held token was loaded only into process memory. Project lookup passed and the pre-create count for `romm-auth-secret-key` was `0`.
+- `bws secret create ... --output none` failed with `404 Resource not found`; a post-error count confirmed the key remains absent (`0`). Sensitive variables were removed by the shell exit trap, and no value was printed or written to disk.
+- Classification: the machine account has read-only project access. The error exactly matches Bitwarden SDK issue [#1287](https://github.com/bitwarden/sdk-sm/issues/1287), which documents this misleading `404` when create permission is missing.
+- Blocker: temporarily grant that machine account **Can read, write** on the existing project, or create the key manually in the Bitwarden web app. No retry is warranted until permission changes.

--- a/.hermes/ledger/2026-07-14-romm-deployment.md
+++ b/.hermes/ledger/2026-07-14-romm-deployment.md
@@ -31,7 +31,7 @@
 - [x] Ansible desired state implemented
 - [x] GitOps manifests implemented
 - [x] Static/render validation complete
-- [ ] Feature commits complete
+- [x] Feature commits complete
 - [ ] Live mutation approvals received
 - [ ] NFS applied and verified
 - [ ] Secret created and verified

--- a/.hermes/ledger/2026-07-14-romm-deployment.md
+++ b/.hermes/ledger/2026-07-14-romm-deployment.md
@@ -33,14 +33,13 @@
 - [x] Static/render validation complete
 - [x] Feature commits complete
 - [ ] Live mutation approvals received
-- [ ] NFS applied and verified
+- [x] NFS applied and verified
 - [ ] Secret created and verified
 - [ ] GitOps deployed and live health verified
 
 ## Approval gates still closed
 
 - Bitwarden secret creation
-- Lyris NFS apply
 - Kubernetes server-side dry-run (blocked by the homelab gate)
 - Pull request creation / merge
 - Live Flux reconciliation
@@ -70,5 +69,7 @@ Ansible checks in `/home/sean/workspace/endsys-ansible-romm`:
 - Local exports template render: pass, including `/vault/games    10.127.0.0/24(rw,sync,no_subtree_check,root_squash)`.
 - Direct SSH and Ansible become preflight through `momo` with `/home/sean/.ssh/momo`: pass; `ping: pong` and passwordless become returned UID `0`.
 - Live NFS check mode with the explicit Momo key: pass; `changed=2`, `unreachable=0`, `failed=0`. The only predicted changes are `/vault/games` root metadata (`0:0/0777` to `1000:1000/0775`) and the intended export line.
+- Approved NFS apply reported `ok=32 changed=3 unreachable=0 failed=0`; the third change is the export reload handler. Backup: `/etc/exports.pre-romm-20260715T073321-0400`.
+- Post-apply verification: live export is RW with `root_squash`; `/vault/games` is `1000:1000/0775`; a UID/GID 1000 create/delete NFS probe passed; no probe mounts/files remained; ZFS is healthy; idempotency check passed with `changed=0 failed=0`.
 
-No NFS, Kubernetes, Bitwarden, or Flux live state has been changed. Ahead-only feature branches were pushed; no pull request or merge was created.
+NFS live state changed only as recorded above. No Kubernetes, Bitwarden, or Flux live state has been changed. Ahead-only feature branches were pushed; no pull request or merge was created.

--- a/.hermes/ledger/2026-07-14-romm-deployment.md
+++ b/.hermes/ledger/2026-07-14-romm-deployment.md
@@ -39,8 +39,7 @@
 
 ## Approval gates still closed
 
-- Kubernetes server-side dry-run (blocked by the homelab gate)
-- Pull request creation / merge
+- Pull request merge
 - Live Flux reconciliation
 
 ## Verification evidence
@@ -58,7 +57,7 @@ GitOps checks run independently after both Claude Code workers exhausted their t
 - Live read-only Lyris check: `sean` is UID/GID 1000 and all known game-library directories are mode `0777`. The Ansible share item sets the export root to `1000:1000/0775`; with `fsGroupChangePolicy: OnRootMismatch`, Kubernetes can avoid a recursive ownership walk through the 355 GiB library.
 - Strict kubeconform with core and CRD-catalog schemas after `SECRET_DOMAIN=example.com` substitution: 8/8 ROMM app resources valid, 1/1 Flux Kustomization valid, and 1/1 Velero Schedule valid.
 - `git diff --check`: pass.
-- Kubernetes server-side dry-run: not run; the homelab gate blocked the exact `kubectl apply --dry-run=server` commands and explicitly prohibited retrying or working around the block.
+- Kubernetes server-side admission dry-run: unavailable from the gateway's intentional read-only kubeconfig. The `mimir-readonly` service account has no create permission. The repaired homelab hook allows explicit client/server dry-runs, but Mimir did not bypass the read-only identity with admin credentials.
 
 Ansible checks in `/home/sean/workspace/endsys-ansible-romm`:
 
@@ -71,7 +70,7 @@ Ansible checks in `/home/sean/workspace/endsys-ansible-romm`:
 - Approved NFS apply reported `ok=32 changed=3 unreachable=0 failed=0`; the third change is the export reload handler. Backup: `/etc/exports.pre-romm-20260715T073321-0400`.
 - Post-apply verification: live export is RW with `root_squash`; `/vault/games` is `1000:1000/0775`; a UID/GID 1000 create/delete NFS probe passed; no probe mounts/files remained; ZFS is healthy; idempotency check passed with `changed=0 failed=0`.
 
-NFS live state changed only as recorded above. No Kubernetes or Flux live state has been changed. Ahead-only feature branches were pushed; no pull request or merge was created.
+NFS live state changed only as recorded above. No Kubernetes or Flux live state has been changed. Ahead-only feature branches were pushed; no merge was performed.
 
 ## Bitwarden secret rollout
 
@@ -82,3 +81,18 @@ NFS live state changed only as recorded above. No Kubernetes or Flux live state 
 - Classification: the machine account has read-only project access. The error exactly matches Bitwarden SDK issue [#1287](https://github.com/bitwarden/sdk-sm/issues/1287), which documents this misleading `404` when create permission is missing.
 - Sean created `romm-auth-secret-key` manually in the `endsys-gitops` project. The value was never sent through chat or read back by Mimir.
 - Value-free BWS verification passed: the matching-key count is exactly `1`.
+
+## Readiness revalidation — 2026-07-15
+
+- Opened [shelmus/endsys-gitops#287](https://github.com/shelmus/endsys-gitops/pull/287) (`feat/romm` → `main`). PR creation was explicitly approved; merge and deployment were not.
+- Branch is clean, synchronized with its remote, and not behind `origin/main`.
+- Ansible syntax/lint/YAML validation and both repo diff checks passed.
+- Kustomize renders passed for the ROMM app/namespace, Velero app, and root apps tree. Client dry-run creation passed for the namespace bundle, eight-resource app bundle, Velero Schedule, app-template output, and Dragonfly output.
+- Strict Kubernetes 1.34/CRD schemas passed: ROMM app 8/8, Flux Kustomization 1/1, Velero Schedule 1/1, app-template output 5/5, and Dragonfly output 3/3.
+- Checksum-verified Helm 4.2.3 pulled and rendered app-template 5.0.1 and Dragonfly v1.39.0 from their live OCI sources. `rommapp/romm:4.9.2` remains available for `linux/amd64`.
+- All three Kubernetes nodes and every declared Flux dependency are Ready. The internal Gateway is programmed at `10.127.0.51`; the Bitwarden ClusterSecretStore is Ready.
+- Longhorn is the default StorageClass; all three disks are schedulable with 619–755 GiB currently available, well above the 42 GiB requested by ROMM/CNPG/Dragonfly.
+- Lyris answers NFSv4 RPC, `nfs-server` is active, and ZFS pool `vault` is ONLINE with zero known data errors.
+- `pihole-dns` is Ready with no recent error/timeout log lines. Existing internal routes resolve to the internal Gateway; the ROMM record is expected only after its HTTPRoute exists.
+- Velero controller logs repeatedly mark backup location `default` available; all three node agents are Ready.
+- Post-merge checks remain: ExternalSecret sync, PV/PVC binding, in-pod UID/GID 1000 NFS write probe, CNPG/Dragonfly readiness, ROMM migrations and `/api/heartbeat`, HTTPRoute/DNS/TLS, a small platform scan, and proof from a real backup that volume `library` is excluded.

--- a/.hermes/plans/2026-07-14_190017-romm-deployment.md
+++ b/.hermes/plans/2026-07-14_190017-romm-deployment.md
@@ -1,0 +1,150 @@
+# ROMM Deployment Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Deploy ROMM against the existing 355 GiB library at `/vault/games` on Lyris, while keeping application state backed up and the library itself outside Velero backups.
+
+**Architecture:** ROMM 4.9.2 runs through bjw-s app-template 5.0.1 behind the internal Gateway at `romm.endsys.cloud`. A static retained NFS PV exposes `10.127.0.7:/vault/games` read/write at `/romm/library`; Longhorn PVCs hold mutable ROMM application state, CNPG provides PostgreSQL, and Dragonfly provides the Redis-compatible cache. Lyris's Ansible source of truth exports `/vault/games` only to `10.127.0.0/24` with root squashing.
+
+**Tech Stack:** FluxCD, Kustomize, app-template 5.0.1, ROMM 4.9.2, NFSv4, Longhorn, CloudNativePG, Dragonfly, Gateway API, External Secrets, Bitwarden Secrets Manager, Velero, Ansible.
+
+---
+
+## Fixed decisions
+
+- Reuse `/vault/games`; do not copy or move the existing library.
+- Mount the library read/write at `/romm/library`.
+- Keep the static PV reclaim policy `Retain`.
+- Expose ROMM only through the `internal` Gateway.
+- Bootstrap with ROMM's local setup wizard; Pocket ID OIDC is a separate follow-up.
+- Manage the initial filesystem mapping in Git:
+  - `Nintendo Gameboy` -> `gb`
+  - `Nintendo Gameboy Advance` -> `gba`
+- Do not map or mutate `roms/the-eye.eu` or `/vault/games/roms_other`; ROMM will ignore unsupported top-level data until it is intentionally reorganized.
+- Back up the namespace's Longhorn/CNPG state with Velero, but exclude the NFS library volume from filesystem backup.
+
+## Approval boundaries
+
+Repository edits, local rendering, linting, check mode, and commits are allowed after this plan. The following remain explicit red gates:
+
+1. **Create Bitwarden secret:** generate a 64-byte ROMM auth key and create the `romm-auth-secret-key` secret in the existing Secrets Manager project.
+2. **Apply NFS desired state:** `ansible-playbook playbooks/nas.yml --limit lyris --diff` from the Ansible worktree.
+3. **Create pull requests or merge either branch.**
+4. **Force Flux reconciliation or otherwise mutate the live cluster.**
+
+## Task 1: Add Lyris NFS desired state
+
+**Objective:** Export the existing `/vault/games` directory to the cluster/LAN without changing its contents.
+
+**Files:**
+- Modify in the Ansible repository: `inventory/host_vars/lyris/nas.yml`
+
+**Steps:**
+1. Add a `games` item to `nas_shares` with path `/vault/games`, owner/group `sean`, mode `0775`, NFS export to `10.127.0.0/24`, and options `rw,sync,no_subtree_check,root_squash`.
+2. Do not enable Samba for this share and do not alter any existing share.
+3. Run `ansible-playbook playbooks/nas.yml --syntax-check`.
+4. Run `ansible-playbook playbooks/nas.yml --limit lyris --check --diff`; expected change is the `/vault/games` directory metadata if needed plus one `/etc/exports` entry and export refresh. Stop if unrelated changes appear.
+5. Commit as `feat(nas): export ROMM game library`.
+
+## Task 2: Add ROMM namespace and Flux wiring
+
+**Objective:** Register a standard ROMM namespace and app Kustomization.
+
+**Files:**
+- Create: `kubernetes/apps/romm/kustomization.yaml`
+- Create: `kubernetes/apps/romm/romm/ks.yaml`
+- Modify: `kubernetes/apps/kustomization.yaml`
+
+**Steps:**
+1. Reference the shared `common` component at namespace level.
+2. Make the app Kustomization depend on app-template, CNPG operator, Dragonfly operator, External Secrets stores, NFS CSI, and Longhorn as required by the repository's existing resource names.
+3. Add `./romm` to the cluster apps Kustomization.
+
+## Task 3: Add ROMM storage, database, cache, and configuration
+
+**Objective:** Define all stateful dependencies before the ROMM HelmRelease.
+
+**Files:**
+- Create: `kubernetes/apps/romm/romm/app/kustomization.yaml`
+- Create: `kubernetes/apps/romm/romm/app/library-pv.yaml`
+- Create: `kubernetes/apps/romm/romm/app/library-pvc.yaml`
+- Create: `kubernetes/apps/romm/romm/app/postgres-cluster.yaml`
+- Create: `kubernetes/apps/romm/romm/app/dragonfly.yaml`
+- Create: `kubernetes/apps/romm/romm/app/configmap.yaml`
+- Create: `kubernetes/apps/romm/romm/app/externalsecret.yaml`
+
+**Steps:**
+1. Define a static `ReadWriteMany` NFS PV/PVC for `10.127.0.7:/vault/games`, with blank storage class and `Retain` policy.
+2. Define one-instance CNPG cluster `romm-postgres`, database/owner `romm`, and 10 GiB Longhorn storage.
+3. Define one-replica Dragonfly service `dragonfly` with conservative resources and persistent Longhorn storage matching the namespace-local Immich pattern.
+4. Define Git-managed `config.yml` containing only the two verified folder mappings.
+5. Define `romm-secrets` ExternalSecret with key `ROMM_AUTH_SECRET_KEY` sourced from Bitwarden key `romm-auth-secret-key`.
+
+## Task 4: Add ROMM workload and route
+
+**Objective:** Run ROMM reproducibly and expose it internally.
+
+**Files:**
+- Create: `kubernetes/apps/romm/romm/app/helmrelease.yaml`
+- Create: `kubernetes/apps/romm/romm/app/httproute.yaml`
+
+**Steps:**
+1. Use app-template `5.0.1` and `rommapp/romm:4.9.2`; never use `latest`.
+2. Use `Recreate` strategy because ROMM has RWO PVCs.
+3. Set PostgreSQL environment from `romm-postgres-app`, cache host `dragonfly`, `HASHEOUS_API_ENABLED=true`, timezone `America/New_York`, and `ROMM_AUTH_SECRET_KEY` from `romm-secrets`.
+4. Mount:
+   - retained NFS claim at `/romm/library`;
+   - Longhorn PVCs at `/romm/resources` (20 GiB) and `/romm/assets` (10 GiB);
+   - Git-managed configuration at `/romm/config/config.yml`.
+5. Use the dedicated `/api/heartbeat` endpoint for startup, readiness, and liveness probes.
+6. Annotate the pod to exclude the `library` volume from Velero filesystem backup.
+7. Run as UID/GID 1000 with privilege escalation disabled, all Linux capabilities dropped, RuntimeDefault seccomp, and filesystem group 1000; verify this against the published release image rather than only the source Dockerfile.
+8. Add an internal HTTPRoute for `romm.endsys.cloud` to service port 8080.
+
+## Task 5: Add backup schedule
+
+**Objective:** Back up ROMM application state without copying the ROM library.
+
+**Files:**
+- Create: `kubernetes/apps/velero/velero/app/schedules/romm-schedule.yaml`
+- Modify: `kubernetes/apps/velero/velero/app/kustomization.yaml`
+
+**Steps:**
+1. Follow the existing per-namespace schedule pattern.
+2. Include namespace `romm`, 02:45 daily schedule, 720h retention, and filesystem backup for eligible volumes.
+3. Rely on the ROMM pod's explicit `backup.velero.io/backup-volumes-excludes: library` annotation to skip the NFS library.
+
+## Task 6: Render and verify
+
+**Objective:** Prove that both repositories are internally valid before any live mutation.
+
+**GitOps verification:**
+1. Use the repo-pinned tools where available; if `mise` is absent, use checksummed scratch binaries at the same pinned versions.
+2. Run `yamllint`, exempting only intentionally long schema-annotation URLs.
+3. Run `kubectl kustomize` for the ROMM subtree, Velero subtree, and full apps root.
+4. Render app-template `5.0.1` with Helm using the HelmRelease's exact `spec.values`.
+5. Run strict kubeconform validation against core and CRD-catalog schemas after a disposable Flux domain substitution.
+6. Run server-side dry-run only when the homelab gate permits it.
+7. Verify generated Deployment, Service, PVCs, PV, HTTPRoute, CNPG Cluster, Dragonfly, ExternalSecret, and Velero Schedule fields.
+8. Run `git diff --check` and inspect the full diff.
+
+**Ansible verification:**
+1. Run syntax check.
+2. Run `--check --diff --limit lyris` against `playbooks/nas.yml`.
+3. Confirm no changes outside the intended share/export entry.
+4. Run `git diff --check` and inspect the full diff.
+
+## Task 7: Commit and gated rollout
+
+**Objective:** Prepare reversible commits, then pause at the live-mutation boundary.
+
+**Steps:**
+1. Commit GitOps changes as `feat(romm): deploy ROMM game library`.
+2. Commit Ansible changes as `feat(nas): export ROMM game library`.
+3. Push the two ahead-only feature branches after verification and report doing so.
+4. Present exact commands and expected effects for Bitwarden secret creation, Ansible apply, pull requests/merges, and Flux reconciliation.
+5. After explicit approval, apply NFS first and verify `/etc/exports`, `exportfs -v`, and a temporary NFS mount probe.
+6. Create the Bitwarden secret without printing its value, then verify External Secrets can retrieve it after deployment.
+7. Merge/deploy only after the preceding dependencies are green.
+8. Verify Flux Kustomizations, ROMM pod health, CNPG/Dragonfly readiness, PVC binding, HTTP 200 from `https://romm.endsys.cloud/api/heartbeat`, and that `/romm/library/roms` is visible from the pod.
+9. Record final evidence in `.hermes/ledger/2026-07-14-romm-deployment.md`.

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -26,6 +26,7 @@ resources:
   - ./pelican
   - ./pocket-id
   - ./pricebuddy
+  - ./romm
   - ./taxsale-monitor
   - ./velero
   - ./hindsight

--- a/kubernetes/apps/romm/kustomization.yaml
+++ b/kubernetes/apps/romm/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: romm
+components:
+  - ../../components/common
+resources:
+  - ./romm/ks.yaml

--- a/kubernetes/apps/romm/romm/app/configmap.yaml
+++ b/kubernetes/apps/romm/romm/app/configmap.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: romm-config
+data:
+  config.yml: |
+    system:
+      platforms:
+        "Nintendo Gameboy": gb
+        "Nintendo Gameboy Advance": gba

--- a/kubernetes/apps/romm/romm/app/dragonfly.yaml
+++ b/kubernetes/apps/romm/romm/app/dragonfly.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: dragonfly
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: dragonfly
+      version: v1.39.0
+      sourceRef:
+        kind: HelmRepository
+        name: dragonfly
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    replicaCount: 1
+    extraArgs:
+      - --proactor_threads=1
+      - --cluster_mode=emulated
+      - --default_lua_flags=allow-undeclared-keys
+    storage:
+      enabled: true
+      requests: 2Gi
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 512Mi

--- a/kubernetes/apps/romm/romm/app/externalsecret.yaml
+++ b/kubernetes/apps/romm/romm/app/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: romm-secrets
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden-secretsmanager
+  target:
+    name: romm-secrets
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: ROMM_AUTH_SECRET_KEY
+      remoteRef:
+        key: romm-auth-secret-key

--- a/kubernetes/apps/romm/romm/app/helmrelease.yaml
+++ b/kubernetes/apps/romm/romm/app/helmrelease.yaml
@@ -1,0 +1,150 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: romm
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      romm:
+        strategy: Recreate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          annotations:
+            backup.velero.io/backup-volumes-excludes: library
+        containers:
+          app:
+            image:
+              repository: rommapp/romm
+              tag: 4.9.2
+            env:
+              TZ: America/New_York
+              ROMM_BASE_URL: https://romm.${SECRET_DOMAIN}
+              ROMM_PORT: "8080"
+              ROMM_DB_DRIVER: postgresql
+              DB_HOST: romm-postgres-rw
+              DB_PORT: "5432"
+              DB_NAME: romm
+              DB_USER: romm
+              DB_PASSWD:
+                valueFrom:
+                  secretKeyRef:
+                    name: romm-postgres-app
+                    key: password
+              REDIS_HOST: dragonfly
+              REDIS_PORT: "6379"
+              HASHEOUS_API_ENABLED: "true"
+              SCAN_WORKERS: "2"
+              WEB_SERVER_CONCURRENCY: "2"
+              ROMM_TMP_PATH: /romm/tmp
+              ROMM_AUTH_SECRET_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: romm-secrets
+                    key: ROMM_AUTH_SECRET_KEY
+            probes:
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/heartbeat
+                    port: &port 8080
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 30
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/heartbeat
+                    port: *port
+                  initialDelaySeconds: 60
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/heartbeat
+                    port: *port
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 6
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              seccompProfile:
+                type: RuntimeDefault
+            resources:
+              requests:
+                cpu: 250m
+                memory: 512Mi
+              limits:
+                memory: 4Gi
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+
+    service:
+      app:
+        controller: romm
+        ports:
+          http:
+            port: *port
+
+    persistence:
+      library:
+        type: persistentVolumeClaim
+        existingClaim: romm-library
+        globalMounts:
+          - path: /romm/library
+      resources:
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 20Gi
+        retain: true
+        globalMounts:
+          - path: /romm/resources
+      assets:
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 10Gi
+        retain: true
+        globalMounts:
+          - path: /romm/assets
+      config:
+        type: configMap
+        name: romm-config
+        globalMounts:
+          - path: /romm/config/config.yml
+            subPath: config.yml
+            readOnly: true
+      tmp:
+        type: emptyDir
+        sizeLimit: 5Gi
+        globalMounts:
+          - path: /romm/tmp

--- a/kubernetes/apps/romm/romm/app/httproute.yaml
+++ b/kubernetes/apps/romm/romm/app/httproute.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: romm
+spec:
+  parentRefs:
+    - name: internal
+      namespace: kube-system
+      sectionName: https
+  hostnames:
+    - romm.${SECRET_DOMAIN}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: romm
+          port: 8080

--- a/kubernetes/apps/romm/romm/app/kustomization.yaml
+++ b/kubernetes/apps/romm/romm/app/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml
+  - ./dragonfly.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml
+  - ./library-pv.yaml
+  - ./library-pvc.yaml
+  - ./postgres-cluster.yaml

--- a/kubernetes/apps/romm/romm/app/library-pv.yaml
+++ b/kubernetes/apps/romm/romm/app/library-pv.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: romm-library-pv
+spec:
+  capacity:
+    storage: 8Ti
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  nfs:
+    path: /vault/games
+    server: 10.127.0.7

--- a/kubernetes/apps/romm/romm/app/library-pvc.yaml
+++ b/kubernetes/apps/romm/romm/app/library-pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: romm-library
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  volumeName: romm-library-pv
+  resources:
+    requests:
+      storage: 8Ti

--- a/kubernetes/apps/romm/romm/app/postgres-cluster.yaml
+++ b/kubernetes/apps/romm/romm/app/postgres-cluster.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: romm-postgres
+spec:
+  instances: 1
+  bootstrap:
+    initdb:
+      database: romm
+      owner: romm
+  storage:
+    size: 10Gi

--- a/kubernetes/apps/romm/romm/ks.yaml
+++ b/kubernetes/apps/romm/romm/ks.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app romm
+  namespace: &namespace romm
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: csi-driver-nfs
+      namespace: kube-system
+    - name: cnpg-operator
+      namespace: cnpg-system
+    - name: external-secrets-stores
+      namespace: external-secrets
+    - name: longhorn
+      namespace: longhorn-system
+  interval: 1h
+  path: ./kubernetes/apps/romm/romm/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 10m
+  wait: false

--- a/kubernetes/apps/velero/velero/app/kustomization.yaml
+++ b/kubernetes/apps/velero/velero/app/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - ./schedules/pricebuddy-schedule.yaml
   - ./schedules/n8n-schedule.yaml
   - ./schedules/immich-schedule.yaml
+  - ./schedules/romm-schedule.yaml
   - ./schedules/gatus-schedule.yaml
   - ./schedules/obsidian-livesync-schedule.yaml
   - ./schedules/pocket-id-schedule.yaml

--- a/kubernetes/apps/velero/velero/app/schedules/romm-schedule.yaml
+++ b/kubernetes/apps/velero/velero/app/schedules/romm-schedule.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: romm-daily
+  namespace: velero
+  labels:
+    app.kubernetes.io/name: velero
+    app.kubernetes.io/component: backup-schedule
+    app.kubernetes.io/part-of: romm
+spec:
+  schedule: "45 2 * * *"
+  template:
+    includedNamespaces:
+      - romm
+    includedResources:
+      - '*'
+    defaultVolumesToFsBackup: true
+    storageLocation: default
+    ttl: 720h0m0s
+    includeClusterResources: true
+    metadata:
+      labels:
+        app.kubernetes.io/name: romm
+        backup-type: scheduled
+  useOwnerReferencesInBackup: false


### PR DESCRIPTION
## Summary

- deploy ROMM `4.9.2` through Flux with app-template `5.0.1`
- use CNPG PostgreSQL and Dragonfly for database/cache dependencies
- mount the existing Lyris `/vault/games` library through a static RWX NFS PV/PVC with `Retain`
- retain Longhorn-backed resources and assets PVCs
- source `ROMM_AUTH_SECRET_KEY` through External Secrets and Bitwarden
- expose ROMM only through the internal Gateway at `romm.endsys.cloud`
- exclude the NFS library volume from Velero filesystem backup while scheduling backups for ROMM namespace state

## Validation

- all ROMM, Velero, and root-app Kustomize renders passed
- changed YAML passed `yamllint`; branch diff passed `git diff --check`
- client dry-run creation passed for the namespace bundle, 8-resource app bundle, Velero Schedule, app-template output, and Dragonfly output
- strict Kubernetes/CRD schemas: ROMM app 8/8, Flux Kustomization 1/1, Velero Schedule 1/1
- pinned live OCI chart renders: app-template 5/5 resources and Dragonfly 3/3 resources passed strict Kubernetes 1.34 schemas
- `rommapp/romm:4.9.2` is available for `linux/amd64`; the published image previously passed the recorded UID/GID 1000 restricted-security smoke

## Live prerequisites

- all three Kubernetes nodes are Ready (`amd64`)
- NFS CSI, CNPG, External Secrets stores, Longhorn, the internal Gateway, and the Bitwarden ClusterSecretStore are Ready
- Longhorn is the default StorageClass; all three nodes are schedulable with ample capacity
- NFSv4 on Lyris answers RPC, `nfs-server` is active, and ZFS is online with no known data errors
- the approved NFS rollout and value-free existence check for `romm-auth-secret-key` are recorded in the deployment ledger
- `pihole-dns` is Ready and will create the local ROMM record after the HTTPRoute appears

## Unexercised checks

Server-side admission dry-run is unavailable from the gateway's intentional read-only service account (`mimir-readonly` has no create permission). The manifests instead passed client dry-run plus strict schemas. Actual ExternalSecret sync, PV binding/write access from the pod, migrations, route/DNS, health endpoint, and backup exclusion remain post-merge deployment checks.

## Rollout boundary

Creating this PR does not merge it or reconcile Flux. Merge and deployment remain separate approval gates.
