### PR TITLE
feat(home-assistant): remove USB bootstrap coupling

### DIFF
--- a/.context/hardware/usb-passthrough.md
+++ b/.context/hardware/usb-passthrough.md
@@ -1,5 +1,11 @@
 # USB Device Passthrough on Talos OS
 
+This is an optional recipe for direct USB device access (e.g. a Z-Wave or
+Zigbee stick), for use if and when a workload needs to talk to a physical
+device attached to a specific node. It is not part of the Home Assistant
+household-dashboard baseline, which runs without any USB/hostPath device and
+without node pinning.
+
 ## Finding Device Paths
 
 Talos Linux is immutable — there is no SSH access. Use `talosctl` to interact with nodes.
@@ -57,7 +63,13 @@ additionalMounts:
     readOnly: true
 ```
 
-The pod must run with `securityContext.privileged: true` and a `nodeSelector` pinning it to the node with the device.
+As a last resort, when a workload needs direct access to a physical device,
+grant the minimum device exposure and permissions the workload actually
+requires: expose only the intended device path and add only an explicitly
+required supplemental group or Linux capability. Do not reach for
+`securityContext.privileged: true` by default. Pin the pod to a specific node
+with a `nodeSelector` only when the physical device is actually attached to
+that node.
 
 In Home Assistant, configure the Z-Wave integration with the full path:
 

--- a/.hermes/ledger/2026-07-20-home-assistant-no-usb-dashboard.md
+++ b/.hermes/ledger/2026-07-20-home-assistant-no-usb-dashboard.md
@@ -308,20 +308,104 @@ future approved UI phase; it was not read from the backup or inferred here.
 - Live Velero schedules/backups remain unverified because the read-only identity lacks access.
 - Tablet model, OS, viewport, kiosk features, charging, and burn-in constraints remain unknown and do not block the infrastructure baseline.
 
+## PR B merge and natural rollout — verified 2026-07-26
+
+- PR B #302 merged to `origin/main` as
+  `15c73d4e84fb6f863331e73b2f50bca52fc71cbd`; all four GitHub checks on the
+  merge candidate completed successfully.
+- Flux naturally reconciled HelmRelease revision `home-assistant.v13` with
+  chart `home-assistant@0.3.61`. No manual reconcile, restart, or pod deletion
+  was used.
+- Pod `home-assistant-0` became `1/1 Running` with zero restarts and the public
+  Gateway route returned HTTP 200 with the Home Assistant login page.
+- The setup init container preserved the first pre-overwrite configuration as
+  `/config/configuration.yaml.20260726_184635`. This is the required pristine
+  configuration backup identifier; the init image's clock is not assumed to
+  share the main container's `America/New_York` timezone.
+- The generated configuration retained the normal Home Assistant defaults and
+  one exact `http:` block with `use_x_forwarded_for: true` and only
+  `127.0.0.0/8` plus `10.42.0.0/16` trusted.
+- No reverse-proxy, forwarded-header, or untrusted-proxy warnings appeared.
+  Existing outbound errors to `api.met.no` and `alerts.home-assistant.io`
+  remain a separate network issue.
+- The unauthenticated Gateway user path is proven. Authenticated dashboard,
+  retained integration/entity, Chromecast-discovery, and post-rollout
+  application-backup checks remain user-owned because no Home Assistant owner
+  session or credentials were provided to Mimir.
+
+## PR C implementation and local verification — 2026-07-26
+
+Branch/worktree:
+
+- `feat/home-assistant-usb-decoupling`
+- `/home/sean/workspace/endsys-gitops-worktrees/home-assistant-usb-decoupling`
+- merge base `15c73d4e84fb6f863331e73b2f50bca52fc71cbd`
+
+The source change is deliberately narrow:
+
+- set `forceInit: false`;
+- remove the Home Assistant container's privileged security context;
+- remove the `kube1` node selector;
+- remove dormant USB/Z-Wave comments;
+- update `.context/hardware/usb-passthrough.md` to state that the household
+  baseline needs no direct USB and direct-device access is a last resort.
+
+Verification evidence:
+
+- `git diff --check`: pass.
+- `yamllint`: only the pre-existing 111-character schema comment on line 2;
+  no changed line failed.
+- `kubectl kustomize`: pass for both the app root (HelmRelease plus HTTPRoute)
+  and parent root (Kustomization plus common component resources).
+- Pinned targeted Flux Local base/feature renders: pass with
+  `ghcr.io/allenporter/flux-local:v8.0.1` at digest
+  `sha256:5c8cb0ff9d26a5260a47e7b3949403d80713d80037b9f0e4c02c5efca3588518`.
+- The immutable chart source was reconstructed through GitHub's API from tag
+  `home-assistant-0.3.61` at audited commit
+  `1ff2e477902268c8006fe35259c6cd5e1df1a9aa`; locally packaged chart SHA-256:
+  `a96a3ffacf92a3db879e37dbcebdfaa7e64d64851f85e6db49e77862504dde82`.
+  This was necessary because Xfinity intercepted Git/GitHub release TLS with a
+  `susi.comcast.net` certificate; no TLS verification was disabled.
+- Base render SHA-256:
+  `2ceb75f7f4a7b18a84b5855828f758cb68e4c5c80d021c6ce89d6858e8fbc86f`.
+  Feature render SHA-256:
+  `f37a1b75be14d79d0e4dfca269c5583d3c7b7616d8678690d57d9dbac5673bd3`.
+- Machine comparison proved that only `ConfigMap/init-script` and
+  `StatefulSet/home-assistant` change. The complete 39-line render diff is
+  exactly: `forceInit=true` to `false`, its checksum, privileged mode to the
+  chart default `{}`, and removal of the `kube1` selector. Service, image,
+  resources, host networking, DNS policy, Home Assistant configuration,
+  trusted proxies, and persistent-volume template are unchanged.
+- The host firewall blocked Docker bridge-to-host access. An explicitly
+  approved isolated Docker network and read-only chart-server container were
+  used instead; both test container and network were verified absent after
+  cleanup.
+- Independent Claude Opus review returned `PASS` with no blocker.
+
+Storage correction from live/render evidence:
+
+- The accepted plan's `persistence.existingClaim: home-assistant-config`
+  wording is stale. Neither live values nor source contain `existingClaim`.
+- The real retained claim is `home-assistant-home-assistant-0`, generated from
+  StatefulSet volumeClaimTemplate `home-assistant`, bound to Longhorn volume
+  `pvc-5b8361e2-6318-4976-9011-f4c588290caa` since 2026-05-01.
+- PR C leaves the persistence values and volumeClaimTemplate byte-for-byte
+  unchanged.
+
+Scheduler/port preconditions also pass read-only checks: kube1, kube2, and
+kube3 are Ready, untainted, schedulable Kubernetes and Longhorn nodes. Only
+`home-assistant-0` declares host-network container port 8123; kube2 and kube3
+refuse direct connections on 8123, while kube1 returns the current service.
+
 ## Exact next gate
 
-PR A #296 merged on 2026-07-24 as `0513776573c633d669df7e686af283edc55764e5`.
-Its schedule manifest is present on `origin/main`; current live Velero CR and
-artifact verification remains unavailable to `mimir-readonly` and is not
-silently inferred from Git state.
-
-PR B repository edits and targeted render assertions are complete on
-`feat/home-assistant-proxy-bootstrap`, independent final review passed, and the
-implementation commit was pushed ahead-only with local/remote equality verified.
-Opening the pull request is now the next red gate and requires Sean's separate
-approval. GitHub checks must then pass on that exact head before merge is even
-considered; merge/natural Flux reconciliation and the live Home Assistant
-rollout window remain later, separate red gates.
+Once this ledger and the reviewed PR C source land on the ahead-only feature
+branch, opening PR C is the next red gate and requires Sean's separate
+approval. GitHub checks must pass on that exact head. Merge remains blocked
+until Sean also performs the authenticated Gateway checks (dashboard,
+retained integrations/entities, and Chromecast discovery as applicable) and
+creates a fresh Home Assistant application backup, recording its identifier.
+No PR creation, merge, or live rollout is implied by a feature-branch push.
 
 ## Verification provenance
 

--- a/kubernetes/apps/home-assistant/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home-assistant/home-assistant/app/helmrelease.yaml
@@ -33,12 +33,6 @@ spec:
     hostNetwork: true
     dnsPolicy: ClusterFirstWithHostNet
 
-    securityContext:
-      privileged: true
-
-    nodeSelector:
-      kubernetes.io/hostname: kube1
-
     persistence:
       enabled: true
       storageClass: longhorn
@@ -46,9 +40,7 @@ spec:
 
     configuration:
       enabled: true
-      # One-shot force init for the reverse-proxy bootstrap rollout (PR B).
-      # Reset to false in PR C so the template is not re-merged on restart.
-      forceInit: true
+      forceInit: false
       # Narrowed to loopback plus the Cilium native-routing / pod CIDR that the
       # internal Gateway Envoy sources from. Rendered into the http block below.
       trusted_proxies:
@@ -78,18 +70,6 @@ spec:
         automation: !include automations.yaml
         script: !include scripts.yaml
         scene: !include scenes.yaml
-
-    # Z-wave USB passthrough disabled until device is plugged into kube1
-    # additionalVolumes:
-    #   - name: zwave-usb
-    #     hostPath:
-    #       path: /dev/serial/by-id
-    #       type: Directory
-    #
-    # additionalMounts:
-    #   - name: zwave-usb
-    #     mountPath: /dev/serial/by-id
-    #     readOnly: true
 
     service:
       type: ClusterIP


### PR DESCRIPTION
## Summary

- disable the one-shot Home Assistant configuration merge by setting `configuration.forceInit: false`;
- remove the stale privileged container context and `kube1` node selector;
- remove dormant Z-Wave USB comments from the active HelmRelease;
- clarify that direct USB access is an optional last-resort pattern, not part of the household-dashboard baseline.

## Why

PR #302 repaired the Home Assistant reverse-proxy configuration through a deliberate one-shot merge. Its natural Flux rollout preserved the pristine pre-merge file as:

`/config/configuration.yaml.20260726_184635`

The recent kube1 reboot reran that merge and created a second backup because `forceInit` is still enabled. This follow-up establishes the intended steady state before dashboard work and removes USB-era permissions and placement that have no live device dependency.

## Scope boundaries

This PR does not change:

- Home Assistant chart `0.3.61` or image `2026.5.4`;
- controller type, service, HTTPRoute, resources, or trusted proxies;
- `hostNetwork: true` or `ClusterFirstWithHostNet`;
- the Longhorn persistence values or StatefulSet PVC template;
- Home Assistant integrations, entities, users, dashboards, or application state.

## Verification

- `git diff --check`: pass.
- Feature branch is one commit ahead of current `main` and zero commits behind.
- Local, remote, and GitHub feature heads all equal `bdf283d5c69b01dc3eface8937909873864c6eff`.
- Pushed HelmRelease exactly matches the previously rendered feature input.
- Targeted base/feature render SHA-256 values match the execution ledger.
- Machine render assertions: pass.
  - only `ConfigMap/init-script` and `StatefulSet/home-assistant` change;
  - `forceInit` changes from true to false;
  - privileged mode and the kube1 selector are removed;
  - Home Assistant configuration, trusted proxies, service, image, host networking, DNS policy, and PVC template remain unchanged.
- Independent Claude Opus review: pass, no blocker.
- Current live preconditions:
  - all three Kubernetes and Longhorn nodes are Ready and schedulable;
  - all 23 attached Longhorn volumes are healthy;
  - port 8123 is occupied only on kube1 by the current Home Assistant pod;
  - the internal Gateway returns the Home Assistant login page with HTTP 200 and no browser-console error.

## Rollout gates

Opening this PR does not deploy it. Before merge:

1. GitHub checks must pass on the exact current head.
2. Sean must sign in through `https://home-assistant.endsys.cloud`, confirm the retained dashboard/integrations and relevant discovery behavior, and create a fresh Home Assistant application backup.
3. Merge and the resulting natural Flux rollout require a separate exact approval.

After an approved merge, observe natural Flux reconciliation. Do not force a reconcile or pod restart. Verify the init script renders `forceInit=false`, the pod remains Ready with the same PVC, the container is unprivileged, the kube1 selector is absent, and the authenticated Home Assistant user path still works.
