### PR TITLE
fix(pihole-dns): rotate Pi-hole API password after host rebuild

### DIFF
--- a/kubernetes/apps/network/pihole-dns/app/secret.sops.yaml
+++ b/kubernetes/apps/network/pihole-dns/app/secret.sops.yaml
@@ -4,11 +4,10 @@ kind: Secret
 metadata:
   name: pihole-password-secret
 stringData:
-  pihole-password: ENC[AES256_GCM,data:1OdqfLYcqclExAl6Fg==,iv:jxuEQP1Hm/MGhMEtZAUdYUDdfs2g6P4B+2kOAkFnqDs=,tag:Z4fDut7B4fXMeHfU6gZN2Q==,type:str]
+  pihole-password: ENC[AES256_GCM,data:FhqAvIyi61Cq2I3xkSP8DkwC0/9sdx/S5Y6E/5Tq+4s=,iv:HLLwii4F40qYTbh13ANLKeKeU8wex1gLVzQzUU4a9I4=,tag:NrADmtR6orB8nLzovtpBKg==,type:str]
 sops:
   age:
-    - recipient: age1g7lkx9fgvslwxmz09tkn9896zkux5vxvhplt6xsjxg33x2z4rvyquw83y8
-      enc: |
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
         YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKc2trU1pnTGZIRGRxMm9M
         SUx1a3VZbFkwN3BZNzRQQS9LK1UwcGpRYVU4ClJrN0pMQXZEcjNpWVJsRDVkZ0tM
@@ -16,8 +15,9 @@ sops:
         SjZlajArSC9nMWc5UjE2ZlJNRGlpSVUKT9Q3dAe/n9bO22WIkgZr0+xy7YaCM9m9
         AdeeKt3Bsm4fgBif+h8+NMb8HUuXThJPbZPIH7h7Msj40L2DMi95UQ==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2025-08-18T17:40:53Z"
-  mac: ENC[AES256_GCM,data:Qosnb/G26q2SRTNnZSyC/i0ja/egTVqdNA1gzB+P1XtmH8Op4AXNglvIoCNIbrNdWYzw1EII5Mn+ooxFDaMkAAJRFSIq7O1ZbyXKUW1PJvcV3sTNbRfKDN8SYweHdMqzWJGLX2ypaSeqlxSRAfRmY/zYbtwY6ko93UPOF6gIpH4=,iv:xr4YgFOuOlGbyS7ryRX8rhzluvA5TP5XZ4tFyamU+bo=,tag:JiCfpABqu6Nre6vy9damNw==,type:str]
+      recipient: age1g7lkx9fgvslwxmz09tkn9896zkux5vxvhplt6xsjxg33x2z4rvyquw83y8
   encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-03T15:53:00Z"
+  mac: ENC[AES256_GCM,data:Y+nKPTpvMFQuwiau0M1U71m2yvT1Bhf9eWC+mcAmgttKbSw6d3L+IEC7373NnXuj/fcsBYH5/A9SnGlhTIBIutPc0Q5RKaEn3nJLwhB6BPDfy6RV9GxZRgz+q3L1Ac43pe2mUm7R7benruOACwtohTWhwSEZwv9KVYp5Shp5wN8=,iv:3nc5TbfMvz+Mzi83030TSSkl/MLKo0vyYpvmsab9cZM=,tag:9LfqIKEY34zbwr8rTcLSeQ==,type:str]
   mac_only_encrypted: true
   version: 3.10.2


### PR DESCRIPTION
The pihole host was rebuilt from a bare image after an SD card failure, which reset its web/API password. external-dns has been in CrashLoopBackOff since, failing with:

  level=fatal msg="received 401 status code from request"

so no cluster DNS records have reached Pi-hole. k8s-gateway is unaffected; it serves pods in-cluster and does not depend on Pi-hole config.

Rotates to a freshly generated password that is also stored in the Ansible vault (endsys-ansible, vault_pihole_web_password) and already applied to the host. The previous value was recoverable from this repo and had been exposed during recovery, so it was not reused.

The Ansible pihole role now decides idempotency by asking the API whether the configured password authenticates, making the vaulted value authoritative -- so this secret and the vault must be rotated together or external-dns will 401 again.

Once merged, external-dns recovers on its own: policy is upsert-only with a noop registry, so it rebuilds every record from HTTPRoutes and Services.