### PR TITLE
feat(k8s-gateway): serve DNS over TCP

### DIFF
--- a/kubernetes/apps/network/k8s-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/network/k8s-gateway/app/helmrelease.yaml
@@ -37,6 +37,13 @@ spec:
     service:
       type: LoadBalancer
       port: 53
+      # DNS over TCP is not optional here. Chart 3.7.2 gates BOTH the container
+      # port and the Service port behind `useTcp` (default false), so without
+      # this the LoadBalancer only publishes 53/UDP and every TCP query — a
+      # truncated-response retry, a resolver that forces TCP, `dig +tcp` — just
+      # times out. That becomes load-bearing once UniFi is the household
+      # resolver and conditionally forwards endsys.cloud to this address.
+      useTcp: true
       annotations:
         lbipam.cilium.io/ips: "10.127.0.50"
       externalTrafficPolicy: Cluster


### PR DESCRIPTION
## Summary

Sets `service.useTcp: true` on the `k8s-gateway` HelmRelease so the LoadBalancer at `10.127.0.50` publishes 53/TCP alongside 53/UDP.

Chart 3.7.2 gates **both** the container port and the Service port behind `service.useTcp` (default `false`). Confirmed live before this change: `dig +tcp @10.127.0.50` times out while UDP answers normally.

## Why it matters

Any TCP query — a truncated-response retry, a resolver that forces TCP — currently fails with no fallback. That is tolerable while Pi-hole fronts the zone and can answer from its own cache, but it is load-bearing the moment anything forwards `endsys.cloud` straight to this address. UniFi already has an `NS endsys.cloud -> 10.127.0.50` record in place, so that path is live today.

## Blast radius

Flux reconciles this into the running `k8s-gateway` Service on merge. The chart change adds a port; it does not alter the existing UDP listener or the LoadBalancer IP.

## Verification after merge

```
dig +tcp @10.127.0.50 lyris.endsys.cloud    # must answer, not time out
dig @10.127.0.50 lyris.endsys.cloud         # must still answer
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)